### PR TITLE
Fix typo in popcnt benchmark

### DIFF
--- a/popcnt-speed-comparison/popcnt.c
+++ b/popcnt-speed-comparison/popcnt.c
@@ -8,7 +8,7 @@
 #include "../rdtsc.h"
 
 #define MIN_LEN 256/8
-#define MIN_LEN 1048576*16
+#define MAX_LEN 1048576*16
 #define DELTA 4
 #define LINE_SIZE 128
 #define ITERATIONS 10000


### PR DESCRIPTION
Was talking intrinsics with a friend and he linked this, I tried to run it... and I quite suspect defining `MIN_LEN` twice was a bug :)